### PR TITLE
Update documentation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Zamith
+Copyright (c) 2014-2018 Subvisual
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -103,4 +103,4 @@ Note: Do not forget to add tests for the new features.
 
 ## License
 
-See [`LICENSE.txt`](https://github.com/groupbuddies/omniauth-paymill/blob/master/LICENSE.txt).
+See [`LICENSE.txt`](https://github.com/subvisual/omniauth-paymill/blob/master/LICENSE.txt).

--- a/omniauth-paymill.gemspec
+++ b/omniauth-paymill.gemspec
@@ -7,10 +7,10 @@ Gem::Specification.new do |spec|
   spec.name          = "omniauth-paymill"
   spec.version       = Omniauth::Paymill::VERSION
   spec.authors       = ["Zamith"]
-  spec.email         = ["zamith@groupbuddies.com"]
+  spec.email         = ["zamith@subvisual.co"]
   spec.description   = %q{This gem contains the Paymill Connect strategy for OmniAuth2}
   spec.summary       = %q{OmniAuth2 strategy for Paymill Connect}
-  spec.homepage      = "https://github.com/groupbuddies/omniauth-paymill"
+  spec.homepage      = "https://github.com/subvisual/omniauth-paymill"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Why:

* New year :tada:
* Some links still refer to the `groupbuddies` organization.

This change addresses the issues by:

* Updating the copyright year in the license file;
* Refactoring links to the `subvisual` organization.